### PR TITLE
Fixes Issue #3 Vagrantfile outdated

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # Base Vagrant config for Nucleus Puppet
 
-Vagrant::Config.run do |config|
+Vagrant.configure("2") do |config|
   config.vm.box      = "precise64"
   config.vm.box_url  = "http://files.vagrantup.com/precise64.box"
 
@@ -8,7 +8,7 @@ Vagrant::Config.run do |config|
 
   config.vm.define :master do |master_config|
     master_config.vm.host_name = "testablecode.workshop.phpbenelux.eu"
-    master_config.vm.network :hostonly, "33.33.33.10"
+    master_config.vm.network :hostonly, ip: "33.33.33.10"
     master_config.vm.provision :puppet do |puppet|
       puppet.manifests_path = "vm"
       puppet.manifest_file = "main.pp"
@@ -16,5 +16,8 @@ Vagrant::Config.run do |config|
     end
   end
 
-  config.vm.customize ["modifyvm", :id, "--memory", 1024]
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--memory", 1024]
+  end
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define :master do |master_config|
     master_config.vm.host_name = "testablecode.workshop.phpbenelux.eu"
-    master_config.vm.network :hostonly, ip: "33.33.33.10"
+    master_config.vm.network "private_network", ip: "33.33.33.10"
     master_config.vm.provision :puppet do |puppet|
       puppet.manifests_path = "vm"
       puppet.manifest_file = "main.pp"


### PR DESCRIPTION
Fixed the warning and changed config to use the v2 syntax which will probably help with compatibility for future releases of Vagrant.

Note that you need to update your Vagrant, this Vagrantfile should work with Vagrant >= 1.2
I've only tested it with Vagrant 1.3.5 and none of the previous releases.
And by "tested it" I mean that once "vagrant up" was done, if "vagrant ssh"ed into the box and run phpunit test/ in /vagrant and the test worked.
